### PR TITLE
Must update line

### DIFF
--- a/TheDailyWtf/Views/Home/Index.cshtml
+++ b/TheDailyWtf/Views/Home/Index.cshtml
@@ -33,7 +33,7 @@
                      <li><a href="/articles/The_Brillant_Paula_Bean">The Brillant Paula Bean</a></li>
                      <li><a href="/articles/Special-Delivery">Special Delivery</a></li>
                      <li><a href="/articles/Make-It-Work">Radio WTF: Make It Work</a></li>
-                     <li><a target="_blank" href="https://github.com/tdwtf/WtfWebApp/blob/master/TheDailyWtf/Views/Home/Index.cshtml#L31">Add your favorite...</a></li>
+                     <li><a target="_blank" href="https://github.com/tdwtf/WtfWebApp/blob/master/TheDailyWtf/Views/Home/Index.cshtml#L36">Add your favorite...</a></li>
                   </ul>
                </div>
             </li>


### PR DESCRIPTION
Must be L36 in order for "add your own" to be highlighted. Actually every time someone proposes an article he should update the link. Conversely, in order to never update link to "add your own" it should be placed on top of classic articles.