### PR TITLE
Only change pre whitespace for wrapping

### DIFF
--- a/TheDailyWtf/Content/Css/custom.css
+++ b/TheDailyWtf/Content/Css/custom.css
@@ -62,7 +62,7 @@ table td span.admin-no { padding: 4px; background-color: #ce4d4d; }
 .four.columns aside div.about { padding: 10px; background-color: white; }
 .four.columns aside div.about p { font-size: 12px; }
 
-pre { font-family: Consolas, monospace; white-space:normal}
+pre { font-family: Consolas, monospace; white-space:pre-wrap}
 
 div.previous-article { width: 45%; float: left; }
 div.next-article { width: 45%; float: right; text-align: right; }


### PR DESCRIPTION
Fixes the white space of pre tags only if wrapping is necessary rather than also collapsing sequences of whitespace into a single whitespace. See http://www.w3schools.com/cssref/pr_text_white-space.asp

There is one disadvantage with this approach and that is though it wraps the text properly these wraps are not clearly marked. This means that on mobile devices the really long lines still look like big blocks of text. Alternatively overflow: auto could be used to generate scroll bars for the preformatted text when necessary
