### PR TITLE
add ApiController.cs to compile item list

### DIFF
--- a/TheDailyWtf/TheDailyWtf.csproj
+++ b/TheDailyWtf/TheDailyWtf.csproj
@@ -21,6 +21,12 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <TargetFrameworkProfile />
+    <MvcProjectUpgradeChecked>true</MvcProjectUpgradeChecked>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>12.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -129,6 +135,7 @@
     <Compile Include="Common\Security\AuthorPrincipal.cs" />
     <Compile Include="Controllers\AdsController.cs" />
     <Compile Include="Controllers\AdminController.cs" />
+    <Compile Include="Controllers\ApiController.cs" />
     <Compile Include="Controllers\ArticlesController.cs" />
     <Compile Include="Controllers\AuthorsController.cs" />
     <Compile Include="Controllers\HomeController.cs" />


### PR DESCRIPTION
The ApiController.cs file was not in the compile list and hence wasn't being compiled. this should fix the previous 404 error with the API.