### PR TITLE
Add IRC box to left sidebar

### DIFF
--- a/TheDailyWtf/Views/Home/Index.cshtml
+++ b/TheDailyWtf/Views/Home/Index.cshtml
@@ -105,6 +105,18 @@
       </div>
    </aside>
 
+   <aside>
+      <h5 class="heading"><a class="clean" href="#"><i class="icon-users"></i>WTF Chat</a></h5>
+      <div class="about">
+         <p>
+            The Daily WTF has an <a href="https://en.wikipedia.org/wiki/Internet_Relay_Chat" target="_blank">IRC</a> channel <a href="irc://irc.freenode.net:6667/thedailywtf">#thedailywtf</a> on the <a href="http://freenode.net/" target="_blank">Freenode</a> IRC network where you can find regulars visiting the site.
+         </p>
+         <p>
+            You can join in through your browser by using the <a href="https://webchat.freenode.net/?channels=thedailywtf" target="_blank">webchat</a> or by connecting with an IRC <a href="https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients" target="_blank">client</a>.
+         </p>
+      </div>
+   </aside>
+
 </div>
 
 <div class="eight columns">


### PR DESCRIPTION
This adds the new Freenode IRC channel to frontpage left sidebar. I tried my best with the text but feel free to fix the grammar as you see fit.

![wtfchat](https://cloud.githubusercontent.com/assets/106598/12070193/1324754c-b06f-11e5-8dd9-3b64ad22888e.png)
