### PR TITLE
Load Open Sans via HTTPS

### DIFF
--- a/TheDailyWtf/Content/Css/gumby.css
+++ b/TheDailyWtf/Content/Css/gumby.css
@@ -1,5 +1,5 @@
 ﻿@charset "UTF-8";
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700);
 
 html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video { margin: 0; padding: 0; border: 0; font: inherit; font-size: 100%; vertical-align: baseline; }
 


### PR DESCRIPTION
Chrome outright refuses to load the font otherwise even though I am accessing the site via HTTP.

See also https://what.thedailywtf.com/t/what-font-is-the-main-site-supposed-to-be/50973