### PR TITLE
Remove WTF-worthy rule

### DIFF
--- a/TheDailyWtf/Content/Css/main.less
+++ b/TheDailyWtf/Content/Css/main.less
@@ -1,12 +1,8 @@
-﻿@import "reset";
+@import "reset";
 @import "library";
 
 body {
     background-color: @tdwtf-light-grey;
-    font-family: "Open Sans";
-}
-
-h1, h2, h3, h4, h5, h6, p, a, span, li {
     font-family: "Open Sans";
 }
 


### PR DESCRIPTION
Any of the tags listed should inherit the correct font from the first rule in the file. And it makes code appear in the wrong font.