### PR TITLE
Update copyright date on error pages

### DIFF
--- a/TheDailyWtf/404.aspx
+++ b/TheDailyWtf/404.aspx
@@ -1,5 +1,12 @@
-﻿<% Response.StatusCode = 404 %>
-
+﻿<%@ Page Language="C#" %>
+<%@ Import Namespace="System.Reflection" %>
+<% Response.StatusCode = 404; %>
+<script runat="server">
+    string copyright = typeof(WtfViewModelBase).Assembly.GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false)
+                .Cast<AssemblyCopyrightAttribute>()
+                .First()
+                .Copyright;
+</script>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -43,7 +50,7 @@
             </div>
             <div class="row">
                 <p>
-                    Copyright &#169; 2004 - 2016 Inedo Publishing
+                    <%= copyright %>
                 </p>
             </div>
         </footer>

--- a/TheDailyWtf/404.html
+++ b/TheDailyWtf/404.html
@@ -41,10 +41,13 @@
             </div>
             <div class="row">
                 <p>
-                    Copyright &#169; 2004 - 2016 Inedo Publishing
+                    Copyright &#169; 2004 - <span id="copy-year">2017</span> Inedo Publishing
                 </p>
             </div>
         </footer>
+        <script type="text/javascript">
+            document.getElementById("copy-year").textContent = new Date().getFullYear();
+        </script>
     </div>
 </body>
 </html>

--- a/TheDailyWtf/455.aspx
+++ b/TheDailyWtf/455.aspx
@@ -1,5 +1,12 @@
-﻿<% Response.StatusCode = 404 %>
-
+﻿<%@ Page Language="C#" %>
+<%@ Import Namespace="System.Reflection" %>
+<% Response.StatusCode = 404; %>
+<script runat="server">
+    string copyright = typeof(WtfViewModelBase).Assembly.GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false)
+                .Cast<AssemblyCopyrightAttribute>()
+                .First()
+                .Copyright;
+</script>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -43,7 +50,7 @@
             </div>
             <div class="row">
                 <p>
-                    Copyright &#169; 2004 - 2016 Inedo Publishing
+                    <%= copyright %>
                 </p>
             </div>
         </footer>

--- a/TheDailyWtf/455.html
+++ b/TheDailyWtf/455.html
@@ -41,10 +41,13 @@
             </div>
             <div class="row">
                 <p>
-                    Copyright &#169; 2004 - 2016 Inedo Publishing
+                    Copyright &#169; 2004 - <span id="copy-year">2017</span> Inedo Publishing
                 </p>
             </div>
         </footer>
+        <script type="text/javascript">
+            document.getElementById("copy-year").textContent = new Date().getFullYear();
+        </script>
     </div>
 </body>
 </html>

--- a/TheDailyWtf/500.aspx
+++ b/TheDailyWtf/500.aspx
@@ -1,5 +1,12 @@
-﻿<% Response.StatusCode = 500 %>
-
+﻿<%@ Page Language="C#" %>
+<%@ Import Namespace="System.Reflection" %>
+<% Response.StatusCode = 404; %>
+<script runat="server">
+    string copyright = typeof(WtfViewModelBase).Assembly.GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false)
+                .Cast<AssemblyCopyrightAttribute>()
+                .First()
+                .Copyright;
+</script>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -48,7 +55,7 @@
             </div>
             <div class="row">
                 <p>
-                    Copyright &#169; 2004 - 2016 Inedo Publishing
+                    <%= copyright %>
                 </p>
             </div>
         </footer>

--- a/TheDailyWtf/500.html
+++ b/TheDailyWtf/500.html
@@ -46,10 +46,13 @@
             </div>
             <div class="row">
                 <p>
-                    Copyright &#169; 2004 - 2016 Inedo Publishing
+                    Copyright &#169; 2004 - <span id="copy-year">2017</span> Inedo Publishing
                 </p>
             </div>
         </footer>
+        <script type="text/javascript">
+            document.getElementById("copy-year").textContent = new Date().getFullYear();
+        </script>
     </div>
 </body>
 </html>


### PR DESCRIPTION
While the copyright date for most of the site was updated about six months after the year started, the error pages remained neglected, last touched in 2015 to (what else) update the copyright date.

This PR makes the ASPX error pages follow the same copyright system as the rest of the site, and makes the HTML error pages (supposedly unused) always show the current year if JavaScript is enabled.