### PR TITLE
add "Web 0.1" to Classic Articles

### DIFF
--- a/TheDailyWtf/Views/Home/Index.cshtml
+++ b/TheDailyWtf/Views/Home/Index.cshtml
@@ -39,6 +39,7 @@
                         <li><a href="/articles/The_Call_of_Codethulhu">The Call of Codethulhu</a></li>
                         <li><a href="/articles/The_Big_Red_Button">The Big Red Button</a></li>
                         <li><a href="/articles/Happy_Merge_Day!">Happy Merge Day!</a></li>
+                        <li><a href="/articles/Web_0_0x2e_1">Web 0.1</a></li>
                         <li><a target="_blank" href="https://github.com/tdwtf/WtfWebApp/blob/master/TheDailyWtf/Views/Home/Index.cshtml#L31">Add your favorite...</a></li>
                     </ul>
                     <hr />


### PR DESCRIPTION
With so many references in comments to "wooden tables", I can't believe the original post isn't in the sidebar.