### PR TITLE
add "What Is Truth?" and move "Web 0.1" to top

### DIFF
--- a/TheDailyWtf/Views/Home/Index.cshtml
+++ b/TheDailyWtf/Views/Home/Index.cshtml
@@ -32,6 +32,8 @@
                     <p><b>Classic Articles</b></p>
                     <ul>
                         <li><a href="/articles/The_Brillant_Paula_Bean">The Brillant Paula Bean</a></li>
+                        <li><a href="/articles/What_Is_Truth_0x3f_">What Is Truth?</a></li>
+                        <li><a href="/articles/Web_0_0x2e_1">Web 0.1</a></li>
                         <li><a href="/articles/get_words_from_a_number_which_is_passed_as_a_perimeter_into_this_function">get_words_from_a_number_which_is_passed_as_a_perimeter_into_this_function</a></li>
                         <li><a href="/articles/Special-Delivery">Special Delivery</a></li>
                         <li><a href="/articles/Make-It-Work">Radio WTF: Make It Work</a></li>
@@ -40,7 +42,6 @@
                         <li><a href="/articles/The_Big_Red_Button">The Big Red Button</a></li>
                         <li><a href="/articles/Happy_Merge_Day!">Happy Merge Day!</a></li>
                         <li><a href="/articles/Classic-WTF-The-Indexer">The Indexer</a></li>
-                        <li><a href="/articles/Web_0_0x2e_1">Web 0.1</a></li>
                         <li><a target="_blank" href="https://github.com/tdwtf/WtfWebApp/blob/master/TheDailyWtf/Views/Home/Index.cshtml#L31">Add your favorite...</a></li>
                     </ul>
                     <hr />


### PR DESCRIPTION
I only recently realised that the originator of "FileNotFound" wasn't on the list either. This change seeks to resolve that.

Since "Brillant", "FileNotFound" and "wooden table" get referenced a lot, I think it's appropriate they go at the top together.