### PR TITLE
Disable Autocomplete on Date Pickers

### DIFF
--- a/TheDailyWtf/Views/Admin/EditArticle.cshtml
+++ b/TheDailyWtf/Views/Admin/EditArticle.cshtml
@@ -98,8 +98,8 @@
       <div class="field">
          <div>Publish Date (US Eastern Time, current server time is: @DateTime.Now):</div>
          <div class="date-pair">
-            <input name="date" class="input date" type="text" maxlength="255" value="@Model.Date" />
-            <input name="time" class="input time" type="text" maxlength="255" value="@Model.Time" />
+            <input name="date" class="input date" type="text" maxlength="255" autocomplete="off" value="@Model.Date" />
+            <input name="time" class="input time" type="text" maxlength="255" autocomplete="off" value="@Model.Time" />
          </div>
       </div>
 


### PR DESCRIPTION
The edit article date pickers: some browsers have autocomplete
which fights with the date picker. This disables that autocomplete.

(by "fights" I mean "pops over, blocking access")

This annoys me every time I add new articles.