### PR TITLE
Remove CSS/JS from article bodies

### DIFF
--- a/TheDailyWtf/Content/Css/custom.css
+++ b/TheDailyWtf/Content/Css/custom.css
@@ -98,6 +98,7 @@ div.validation-summary-errors ul li { list-style-type: disc; margin-left: 15px; 
 .comment blockquote p { margin: 0; padding: 5px; }
 .comment form { margin-bottom: 0; }
 .article-body .comment { border: none };
+pre .comment { border: none };
 
 .comments-link { float: right; color: #08c; background: #e0f5ff; padding: 8px 20px; margin-left: 10px; font-size: 16px; vertical-align: top; }
 

--- a/TheDailyWtf/Views/Articles/ViewArticle.cshtml
+++ b/TheDailyWtf/Views/Articles/ViewArticle.cshtml
@@ -28,7 +28,9 @@
             <div class="comment-container">
                 <a itemprop="discussionUrl" class="comments" href="@Model.Article.CommentsUrl">View all <span itemprop="commentCount" class="number-of-comments">@Model.Article.CachedCommentCount</span> comments &raquo;</a>
             </div>
-
+            <link rel="stylesheet" href="//thedailywtf.com/images/highlight/styles/github.css"/>
+            <script src="//thedailywtf.com/images/highlight/highlight.pack.js"></script>
+            <script>hljs.initHighlightingOnLoad();</script>
             <!-- AddToAny BEGIN -->
             <div class="a2a_kit a2a_kit_size_32 a2a_default_style" style="padding:5px;">
                 <a class="a2a_button_hacker_news"></a>


### PR DESCRIPTION
Puts the source code highlighter in the page template, and puts the CSS fix for the .comment class into the custom.css file.